### PR TITLE
Use RecordRtc

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
+    "recordrtc": "^5.5.9",
     "vue": "^2.6.11"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,28 +13,34 @@ export default {
   data() {
     return {
       isRecording: false,
+      hasMediaDeviceCaps: false,
       startedRecording: null,
       mediaRecorder: null,
+      isIosDevice: !!navigator.userAgent.match(/iPhone|iPad|iPod/i) || false
     };
   },
   mounted() {
     this.grantPermissions();
   },
   methods: {
-    grantPermissions() {
+    async grantPermissions() {
       let t = this;
-      navigator.mediaDevices
-        .getUserMedia({ audio: true })
-        .then(function(stream) {})
-        .catch(function(err) {});
+      try {
+        navigator.mediaDevices
+          .getUserMedia({ audio: true })
+          .then(() => (this.hasMediaDeviceCaps = true))
+          .catch(() => (this.hasMediaDeviceCaps = false));
+      } catch (err) {
+        this.hasMediaDeviceCaps = false;
+      }
     },
     record() {
       if (!this.isRecording) {
         this.isRecording = true;
-        navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+        navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
           var options = {
             audioBitsPerSecond: 128000,
-            mimeType: "audio/webm;codecs=opus",
+            mimeType: "audio/webm;codecs=opus"
           };
           this.mediaRecorder = new MediaRecorder(stream, options);
           this.mediaRecorder.ondataavailable = this.handleDataAvailable;
@@ -43,14 +49,17 @@ export default {
         });
       } else {
         this.isRecording = false;
-        this.mediaRecorder.stop();
-        this.mediaRecorder.stream.getTracks().forEach((i) => i.stop());
+        if (this.mediaRecorder) {
+          this.mediaRecorder.stop();
+          if (this.mediaRecorder.stream)
+            this.mediaRecorder.stream.getTracks().forEach(i => i.stop());
+        }
       }
     },
     handleDataAvailable(e) {
       this.$refs.audio.src = URL.createObjectURL(e.data);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5013,6 +5013,11 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+recordrtc@^5.5.9:
+  version "5.5.9"
+  resolved "https://registry.yarnpkg.com/recordrtc/-/recordrtc-5.5.9.tgz#cda4b4c965a499cfa9d5b23e27f2043fb3d28399"
+  integrity sha512-6T1tn80nRfsXrAoYWINwz+hBKk+pB5Im4I0BS52Og1ruQvrEdV3IUcm+AKwLMHNyBAhJ2DaVa+9pukTRxMF/uA==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
# Audio Recording on IOS/OSX

Important: keep in mind that to be able to acces the mic on ios you need to run your local env using https, otherwise the os won't allow accessing the mic.

MediaRecorder API is poorly supported and needs to be activated as an experimental feature on both, desktop and mobile safari (on desktop by using safari's developer mode settings, on mobile by using settings>safari>advanced>experimental-feature). I would call this a no-go for the ux but thats up tp you to decide. See <https://caniuse.com/#feat=mediarecorder>

## alternatives

### [Input Capture](https://caniuse.com/#feat=html-media-capture)

Instead of accessing the mic directly use voice recording app provided by Os. (approach promoted on google developers: <https://developers.google.com/web/fundamentals/media/recording-audio>)

Unfortunately does not work for the "microphone" case but should be kept in mind for future development.

- see <https://bugs.webkit.org/show_bug.cgi?id=202039>

```html
<input type="file" accept="image/*" capture="camera" />
<input type="file" accept="video/*" capture="camcorder" />
<input type="file" accept="audio/*" capture="microphone" />
```

### [RecordRTC](https://github.com/muaz-khan/RecordRTC)

Use cross browser RecordRTC lib. Postpone the headache of implementing/testing cross browser logic yourself. Has the benefit that ios/osx users don't need to enable the experimental mediaRecorder api.

## Outcome

You can see the recordrtc implementation in this pr.
I tested it on mobile & desktop safari and chrome, edge and firefox.

## Further suggestions
Generally, since the scope of the application is relatively small it could be a good choice to provide native apps or vue/react-native approaches to have better acces to hardware peripherals. Flutter could also be a feasible approach here. From a user perspective i would guess that the succes of the application will be based on the friction of the default use scenario, which potentially is mainly on mobile.
